### PR TITLE
Truncate messages to not fail ingestion

### DIFF
--- a/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
+++ b/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
@@ -80,9 +80,7 @@ public class RemoteProgressBarSender implements ProgressBar {
 
     private void send(Request.Type type, @Nullable String message) {
         try {
-            if (message != null && message.length() + 1 > MAX_MESSAGE_SIZE) {
-                message = message.substring(0, MAX_MESSAGE_SIZE - 4) + "...";
-            }
+            message = truncateMessage(message, MAX_MESSAGE_SIZE - 1);
             byte[] buf = (type.ordinal() + (message == null ? "" : message)).getBytes();
             DatagramPacket packet = new DatagramPacket(buf, buf.length, address, port);
             socket.send(packet);
@@ -91,6 +89,13 @@ public class RemoteProgressBarSender implements ProgressBar {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private static String truncateMessage(String message, int maxLength) {
+        if (message == null || message.length() <= maxLength) {
+            return message;
+        }
+        return "..." + message.substring(Math.max(message.length() - maxLength - 3, 0));
     }
 
     @Value

--- a/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
+++ b/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
@@ -91,7 +91,7 @@ public class RemoteProgressBarSender implements ProgressBar {
         }
     }
 
-    private static String truncateMessage(String message, int maxLength) {
+    private static @Nullable String truncateMessage(@Nullable String message, int maxLength) {
         if (message == null || message.length() <= maxLength) {
             return message;
         }

--- a/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
+++ b/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
@@ -80,6 +80,8 @@ public class RemoteProgressBarSender implements ProgressBar {
 
     private void send(Request.Type type, @Nullable String message) {
         try {
+            // UTF-8 encoding is not guaranteed to be 1 byte per character, might handle that in the future as per:
+            // https://github.com/openrewrite/rewrite-polyglot/pull/17#discussion_r1322841060
             message = truncateMessage(message, MAX_MESSAGE_SIZE - 1);
             byte[] buf = (type.ordinal() + (message == null ? "" : message)).getBytes();
             DatagramPacket packet = new DatagramPacket(buf, buf.length, address, port);

--- a/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
+++ b/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
@@ -91,11 +91,11 @@ public class RemoteProgressBarSender implements ProgressBar {
         }
     }
 
-    private static @Nullable String truncateMessage(@Nullable String message, int maxLength) {
+    static @Nullable String truncateMessage(@Nullable String message, int maxLength) {
         if (message == null || message.length() <= maxLength) {
             return message;
         }
-        return "..." + message.substring(Math.max(message.length() - maxLength - 3, 0));
+        return "..." + message.substring(Math.max(message.length() - maxLength + 3, 0));
     }
 
     @Value

--- a/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
+++ b/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
@@ -81,7 +81,7 @@ public class RemoteProgressBarSender implements ProgressBar {
     private void send(Request.Type type, @Nullable String message) {
         try {
             if (message != null && message.length() + 1 > MAX_MESSAGE_SIZE) {
-                throw new IllegalArgumentException("Message size exceeded maximum length: " + message);
+                message = message.substring(0, MAX_MESSAGE_SIZE - 4) + "...";
             }
             byte[] buf = (type.ordinal() + (message == null ? "" : message)).getBytes();
             DatagramPacket packet = new DatagramPacket(buf, buf.length, address, port);


### PR DESCRIPTION
## What's changed?
When message size exceeds maximum length truncate, rather than throw an exception.

## What's your motivation?
Stops us from breaking ingestion when Maven/Gradle messages exceed maximum length.

## Have you considered any alternatives or workarounds?
We could make it even more clear that the message was truncated, or truncate elsewhere than at the end.

## Any additional context
Ingestion failures for apache/maven and kiegroup/drools.