### PR TITLE
Prevent potential `NPE`

### DIFF
--- a/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
+++ b/src/main/java/org/openrewrite/polyglot/RemoteProgressBarSender.java
@@ -47,7 +47,9 @@ public class RemoteProgressBarSender implements ProgressBar {
             if (localhost.equals("host.docker.internal")) {
                 try {
                     this.address = InetAddress.getByName("localhost");
-                } catch (UnknownHostException ex) {
+                    this.port = port;
+                    this.socket = new DatagramSocket();
+                } catch (UnknownHostException | SocketException ex) {
                     throw new UncheckedIOException(ex);
                 }
             } else {


### PR DESCRIPTION
If the `RemoteProgressBarSender` constructor runs into a `UnknownHostException` the `socket` field will end up being uninitialized, which then later can result in `NPE`s.
