### PR TITLE
fix: confine OmniParser.acceptedPaths(Path rootDir, Path searchDir) results to searchDir when rootDir is a Git repository

### DIFF
--- a/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
+++ b/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
@@ -84,6 +84,9 @@ public class OmniParserTest {
           "gitignored.xml",
           "localexclude.xml"
         );
+
+        assertThat(parser.acceptedPaths(repo, repo.resolve("folder")))
+          .containsExactlyInAnyOrder(repo.resolve("folder/fileinfolder.xml"));
     }
 
     void initGit(Path repositoryPath) {


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-polyglot/issues/24

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
