### PR TITLE
Add RemoteException#getPartialSuccess

### DIFF
--- a/src/test/java/org/openrewrite/polyglot/RemoteExceptionTest.java
+++ b/src/test/java/org/openrewrite/polyglot/RemoteExceptionTest.java
@@ -17,17 +17,62 @@ package org.openrewrite.polyglot;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RemoteExceptionTest {
-    RemoteException remote = RemoteException.builder("This is a bad thing")
-      .cause(new RuntimeException("boom"), "org.openrewrite")
-      .fixSuggestions("Please fix")
-      .build();
 
     @Test
     void encodeDecode() {
+        RemoteException remote = RemoteException.builder("This is a bad thing")
+          .cause(new RuntimeException("boom"), "org.openrewrite")
+          .fixSuggestions("Please fix")
+          .partialSuccess(true)
+          .build();
+
         RemoteException decoded = RemoteException.decode(remote.encode());
         assertThat(decoded).isEqualTo(remote);
+    }
+
+    @Test
+    void encodeDecodeWithoutCause() {
+        RemoteException remote = RemoteException.builder("This is a bad thing")
+          .fixSuggestions("Please fix")
+          .build();
+
+        RemoteException decoded = RemoteException.decode(remote.encode());
+        assertThat(decoded).isEqualTo(remote);
+    }
+
+    @Test
+    void encodeDecodeWithoutSuggestions() {
+        RemoteException remote = RemoteException.builder("This is a bad thing")
+          .cause(new RuntimeException("boom"), "org.openrewrite")
+          .build();
+
+        RemoteException decoded = RemoteException.decode(remote.encode());
+        assertThat(decoded).isEqualTo(remote);
+    }
+
+    @Test
+    void decodeWithoutPartialSuccess() {
+        // To test deserializing exceptions serialized using legacy versions of rewrite-polyglot
+        Base64.Encoder base64 = Base64.getEncoder();
+        StringBuilder builder = new StringBuilder(256);
+        builder.append(base64.encodeToString("This is a bad thing".getBytes(UTF_8))).append('\n');
+        builder.append("null").append('\n');
+        builder.append("null");
+
+        RemoteException remote = RemoteException.builder("This is a bad thing")
+          .build();
+
+        RemoteException decoded = RemoteException.decode(builder.toString());
+        assertThat(decoded.getMessage()).isEqualTo(remote.getMessage());
+        assertThat(decoded.getCause()).isEqualTo(remote.getCause());
+        assertThat(decoded.getFixSuggestions()).isEqualTo(remote.getFixSuggestions());
+        assertThat(decoded.isPartialSuccess()).isEqualTo(remote.isPartialSuccess());
     }
 }

--- a/src/test/java/org/openrewrite/polyglot/RemoteExceptionTest.java
+++ b/src/test/java/org/openrewrite/polyglot/RemoteExceptionTest.java
@@ -17,10 +17,9 @@ package org.openrewrite.polyglot;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RemoteExceptionTest {
@@ -39,9 +38,7 @@ class RemoteExceptionTest {
 
     @Test
     void encodeDecodeWithoutCause() {
-        RemoteException remote = RemoteException.builder("This is a bad thing")
-          .fixSuggestions("Please fix")
-          .build();
+        RemoteException remote = RemoteException.builder("This is a bad thing").fixSuggestions("Please fix").build();
 
         RemoteException decoded = RemoteException.decode(remote.encode());
         assertThat(decoded).isEqualTo(remote);
@@ -62,12 +59,11 @@ class RemoteExceptionTest {
         // To test deserializing exceptions serialized using legacy versions of rewrite-polyglot
         Base64.Encoder base64 = Base64.getEncoder();
         StringBuilder builder = new StringBuilder(256);
-        builder.append(base64.encodeToString("This is a bad thing".getBytes(UTF_8))).append('\n');
+        builder.append(base64.encodeToString("This is a bad thing".getBytes(StandardCharsets.UTF_8))).append('\n');
         builder.append("null").append('\n');
         builder.append("null");
 
-        RemoteException remote = RemoteException.builder("This is a bad thing")
-          .build();
+        RemoteException remote = RemoteException.builder("This is a bad thing").build();
 
         RemoteException decoded = RemoteException.decode(builder.toString());
         assertThat(decoded.getMessage()).isEqualTo(remote.getMessage());


### PR DESCRIPTION
## What's changed?
Added the field `partialSuccess` to `RemoteException` to indicate a command throwing an exception was partially successful.

## What's your motivation?
The change provides finer granularity when reporting exit status of commands throwing `RemoteException`

## Anything in particular you'd like reviewers to focus on?
Any potential backwards compatibility issues.

## Anyone you would like to review specifically?
@timtebeek @sambsnyd 

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
