### PR TITLE
Stop skipping the .moderne folder

### DIFF
--- a/src/main/java/org/openrewrite/polyglot/OmniParser.java
+++ b/src/main/java/org/openrewrite/polyglot/OmniParser.java
@@ -87,8 +87,7 @@ public class OmniParser implements Parser {
             "node_modules",
             ".git",
             ".metadata",
-            ".DS_Store",
-            ".moderne"
+            ".DS_Store"
     );
 
     private final Collection<Path> exclusions;


### PR DESCRIPTION
## What's changed?
Stop automatically skipping the `.moderne` folder.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
