### PR TITLE
Fix empty relative path handling in OmniParser

### DIFF
--- a/src/main/java/org/openrewrite/polyglot/OmniParser.java
+++ b/src/main/java/org/openrewrite/polyglot/OmniParser.java
@@ -136,7 +136,8 @@ public class OmniParser implements Parser {
     }
 
     public List<Path> acceptedPaths(Path rootDir, Path searchDir) {
-        if (!Files.exists(searchDir)) {
+        Path normalizedSearchDir = searchDir.normalize();
+        if (!Files.exists(normalizedSearchDir)) {
             return emptyList();
         }
 
@@ -151,14 +152,10 @@ public class OmniParser implements Parser {
                 // FileTreeIterator.createSubtreeIterator() can check the index
                 // before skipping ignored directories containing tracked files.
                 fileTreeIterator.setDirCacheIterator(walk, 1);
-                // We use git for walking the file tree, and we should confine the walk to searchDir only
-                // jgit does not support empty path filter, so we refrain from adding a filter when
-                // searchDir is exactly the same as rootDir
-                if (!rootDir.equals(searchDir)) {
-                    String relativePath = separatorsToUnix(rootDir.relativize(searchDir).toString());
-                    if (!relativePath.isEmpty()) {
-                        walk.setFilter(PathFilter.create(relativePath));
-                    }
+                // Confine the tree walk to searchDir; skip the filter when searchDir is rootDir
+                if (!rootDir.equals(normalizedSearchDir)) {
+                    String relativePath = separatorsToUnix(rootDir.relativize(normalizedSearchDir).toString());
+                    walk.setFilter(PathFilter.create(relativePath));
                 }
                 while (walk.next()) {
                     FileTreeIterator workingTreeIterator = walk.getTree(0, FileTreeIterator.class);
@@ -195,11 +192,11 @@ public class OmniParser implements Parser {
             }
         } else {
             try {
-                Files.walkFileTree(searchDir, new SimpleFileVisitor<Path>() {
+                Files.walkFileTree(normalizedSearchDir, new SimpleFileVisitor<Path>() {
                     @Override
                     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
                         return isExcluded(dir, rootDir) ||
-                                isIgnoredDirectory(dir, searchDir) ?
+                                isIgnoredDirectory(dir, normalizedSearchDir) ?
                                 FileVisitResult.SKIP_SUBTREE :
                                 FileVisitResult.CONTINUE;
                     }

--- a/src/main/java/org/openrewrite/polyglot/OmniParser.java
+++ b/src/main/java/org/openrewrite/polyglot/OmniParser.java
@@ -149,10 +149,9 @@ public class OmniParser implements Parser {
                 // searchDir is exactly the same as rootDir
                 if (!rootDir.equals(searchDir)) {
                     String relativePath = separatorsToUnix(rootDir.relativize(searchDir).toString());
-                    if (relativePath.isEmpty()) {
-                        relativePath = ".";
+                    if (!relativePath.isEmpty()) {
+                        walk.setFilter(PathFilter.create(relativePath));
                     }
-                    walk.setFilter(PathFilter.create(relativePath));
                 }
                 while (walk.next()) {
                     for (int i = 0; i < walk.getTreeCount(); i++) {

--- a/src/main/java/org/openrewrite/polyglot/OmniParser.java
+++ b/src/main/java/org/openrewrite/polyglot/OmniParser.java
@@ -149,6 +149,9 @@ public class OmniParser implements Parser {
                 // searchDir is exactly the same as rootDir
                 if (!rootDir.equals(searchDir)) {
                     String relativePath = separatorsToUnix(rootDir.relativize(searchDir).toString());
+                    if (relativePath.isEmpty()) {
+                        relativePath = ".";
+                    }
                     walk.setFilter(PathFilter.create(relativePath));
                 }
                 while (walk.next()) {

--- a/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
+++ b/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
@@ -65,6 +65,7 @@ class OmniParserTest {
 
         mkdirs(repo.resolve("build").toFile());
         touch(repo.resolve("ignored_directory_file.xml"));
+
         if (gitRepo) {
             initGit(repo);
 
@@ -95,9 +96,39 @@ class OmniParserTest {
 
         assertThat(parser.acceptedPaths(repo, repo.resolve("folder")))
           .containsExactlyInAnyOrder(repo.resolve("folder/fileinfolder.xml"));
+    }
 
-        // root should be ignored
-        parser.acceptedPaths(repo, repo.resolve("folder/.."));
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void acceptedPathsWithUnnormalizedSearchDir(boolean gitRepo) throws Exception {
+        touch(repo.resolve("file.xml"));
+        mkdirs(repo.resolve("folder/subfolder").toFile());
+        touch(repo.resolve("folder/fileinfolder.xml"));
+
+        if (gitRepo) {
+            initGit(repo);
+        }
+
+        OmniParser parser = OmniParser.builder(OmniParser.defaultResourceParsers()).build();
+
+        List<Path> rootPaths = normalized(parser.acceptedPaths(repo));
+
+        // All resolve back to root — should return same files as acceptedPaths(repo, repo)
+        assertThat(normalized(parser.acceptedPaths(repo, repo.resolve("folder/.."))))
+          .containsExactlyInAnyOrderElementsOf(rootPaths);
+        assertThat(normalized(parser.acceptedPaths(repo, repo.resolve("."))))
+          .containsExactlyInAnyOrderElementsOf(rootPaths);
+        assertThat(normalized(parser.acceptedPaths(repo, repo.resolve("folder/subfolder/../.."))))
+          .containsExactlyInAnyOrderElementsOf(rootPaths);
+
+        // Resolves to "folder" — should return same as explicit folder search
+        List<Path> folderPaths = normalized(parser.acceptedPaths(repo, repo.resolve("folder")));
+        assertThat(normalized(parser.acceptedPaths(repo, repo.resolve("folder/../folder"))))
+          .containsExactlyInAnyOrderElementsOf(folderPaths);
+    }
+
+    private static List<Path> normalized(List<Path> paths) {
+        return paths.stream().map(Path::normalize).toList();
     }
 
     /**

--- a/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
+++ b/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
@@ -65,8 +65,6 @@ class OmniParserTest {
 
         mkdirs(repo.resolve("build").toFile());
         touch(repo.resolve("ignored_directory_file.xml"));
-
-
         if (gitRepo) {
             initGit(repo);
 

--- a/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
+++ b/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
@@ -56,8 +56,6 @@ class OmniParserTest {
         touch(repo.resolve("file.xml"));
         mkdirs(repo.resolve("folder").toFile());
         touch(repo.resolve("folder/fileinfolder.xml"));
-        // root should be ignored
-        repo.resolve("folder/..");
         touch(repo.resolve("newfile.xml"));
         mkdirs(repo.resolve(".gradle").toFile());
         touch(repo.resolve(".gradle/foo.yml"));
@@ -99,6 +97,9 @@ class OmniParserTest {
 
         assertThat(parser.acceptedPaths(repo, repo.resolve("folder")))
           .containsExactlyInAnyOrder(repo.resolve("folder/fileinfolder.xml"));
+
+        // root should be ignored
+        parser.acceptedPaths(repo, repo.resolve("folder/.."));
     }
 
     /**

--- a/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
+++ b/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
@@ -56,6 +56,8 @@ class OmniParserTest {
         touch(repo.resolve("file.xml"));
         mkdirs(repo.resolve("folder").toFile());
         touch(repo.resolve("folder/fileinfolder.xml"));
+        // root should be ignored
+        repo.resolve("folder/..");
         touch(repo.resolve("newfile.xml"));
         mkdirs(repo.resolve(".gradle").toFile());
         touch(repo.resolve(".gradle/foo.yml"));
@@ -65,6 +67,7 @@ class OmniParserTest {
 
         mkdirs(repo.resolve("build").toFile());
         touch(repo.resolve("ignored_directory_file.xml"));
+
 
         if (gitRepo) {
             initGit(repo);


### PR DESCRIPTION


<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Handle empty `relativePath` case in `OmniParser`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
When running `mvn rewrite:run` for the [Jackson Migration](https://docs.openrewrite.org/recipes/java/jackson/upgradejackson_2_3#usage). There was an exception.
It would stem from `rootDir=""` and `searchDir="dir/.."`.
```
IllegalArgumentException: Empty path not permitted.
at org.openrewrite.jgit.treewalk.filter.PathFilter.create (PathFilter.java:48)
at org.openrewrite.polyglot.OmniParser.acceptedPaths (OmniParser.java:152)
at org.openrewrite.maven.MavenMojoProjectParser.processMainSources (MavenMojoProjectParser.java:522)
at org.openrewrite.maven.MavenMojoProjectParser.listSourceFiles (MavenMojoProjectParser.java:213)
```

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Nope

## Anyone you would like to review specifically?
<!-- @mention them here -->
Nope

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Nope

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
**Feel free to take this PR over to clean it up and merge it.**

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
