### PR TITLE
Fix tracked files matching .gitignore being skipped in acceptedPaths

### DIFF
--- a/src/main/java/org/openrewrite/polyglot/OmniParser.java
+++ b/src/main/java/org/openrewrite/polyglot/OmniParser.java
@@ -29,6 +29,7 @@ import org.openrewrite.hcl.HclParser;
 import org.openrewrite.jgit.api.Git;
 import org.openrewrite.jgit.lib.FileMode;
 import org.openrewrite.jgit.lib.Repository;
+import org.openrewrite.jgit.dircache.DirCacheIterator;
 import org.openrewrite.jgit.treewalk.FileTreeIterator;
 import org.openrewrite.jgit.treewalk.TreeWalk;
 import org.openrewrite.jgit.treewalk.filter.PathFilter;
@@ -143,7 +144,13 @@ public class OmniParser implements Parser {
         Repository repository = getRepository(rootDir);
         if (repository != null) {
             try (TreeWalk walk = new TreeWalk(repository)) {
-                walk.addTree(new FileTreeIterator(repository));
+                FileTreeIterator fileTreeIterator = new FileTreeIterator(repository);
+                walk.addTree(fileTreeIterator);
+                walk.addTree(new DirCacheIterator(repository.readDirCache()));
+                // Link the FileTreeIterator to the DirCacheIterator so that
+                // FileTreeIterator.createSubtreeIterator() can check the index
+                // before skipping ignored directories containing tracked files.
+                fileTreeIterator.setDirCacheIterator(walk, 1);
                 // We use git for walking the file tree, and we should confine the walk to searchDir only
                 // jgit does not support empty path filter, so we refrain from adding a filter when
                 // searchDir is exactly the same as rootDir
@@ -152,27 +159,31 @@ public class OmniParser implements Parser {
                     walk.setFilter(PathFilter.create(relativePath));
                 }
                 while (walk.next()) {
-                    for (int i = 0; i < walk.getTreeCount(); i++) {
-                        FileTreeIterator workingTreeIterator = walk.getTree(i, FileTreeIterator.class);
-                        String pathString = workingTreeIterator.getEntryPathString();
-                        Path path = rootDir.resolve(pathString);
-                        FileMode mode = workingTreeIterator.getEntryFileMode();
-                        if (mode.equals(FileMode.TREE) &&
-                                !isExcluded(path, rootDir) &&
-                                !DEFAULT_IGNORED_DIRECTORIES.contains(path.getFileName().toString()) &&
-                                !workingTreeIterator.isEntryIgnored()) {
-                            walk.enterSubtree();
-                        } else if ((mode.equals(FileMode.EXECUTABLE_FILE) || mode.equals(FileMode.REGULAR_FILE)) &&
-                                !workingTreeIterator.isEntryIgnored() &&
-                                !isExcluded(path, rootDir) &&
-                                // Use getEntryLength() (stat-based) instead of getEntryContentLength()
-                                // which reads the entire file through jgit's filter pipeline.
-                                isWithinSizeThreshold(workingTreeIterator.getEntryLength())) {
-                            for (Parser parser : parsers) {
-                                if (parser.accept(path)) {
-                                    accepted.add(path);
-                                    break;
-                                }
+                    FileTreeIterator workingTreeIterator = walk.getTree(0, FileTreeIterator.class);
+                    if (workingTreeIterator == null) {
+                        continue;
+                    }
+                    DirCacheIterator dirCacheIterator = walk.getTree(1, DirCacheIterator.class);
+                    String pathString = workingTreeIterator.getEntryPathString();
+                    Path path = rootDir.resolve(pathString);
+                    FileMode mode = workingTreeIterator.getEntryFileMode();
+                    // Only treat as ignored if it matches gitignore AND is not tracked in the index
+                    boolean isIgnored = workingTreeIterator.isEntryIgnored() && dirCacheIterator == null;
+                    if (mode.equals(FileMode.TREE) &&
+                            !isExcluded(path, rootDir) &&
+                            !DEFAULT_IGNORED_DIRECTORIES.contains(path.getFileName().toString()) &&
+                            !isIgnored) {
+                        walk.enterSubtree();
+                    } else if ((mode.equals(FileMode.EXECUTABLE_FILE) || mode.equals(FileMode.REGULAR_FILE)) &&
+                            !isIgnored &&
+                            !isExcluded(path, rootDir) &&
+                            // Use getEntryLength() (stat-based) instead of getEntryContentLength()
+                            // which reads the entire file through jgit's filter pipeline.
+                            isWithinSizeThreshold(workingTreeIterator.getEntryLength())) {
+                        for (Parser parser : parsers) {
+                            if (parser.accept(path)) {
+                                accepted.add(path);
+                                break;
                             }
                         }
                     }

--- a/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
+++ b/src/test/java/org/openrewrite/polyglot/OmniParserTest.java
@@ -155,6 +155,59 @@ class OmniParserTest {
           .doesNotContain(Path.of("project/.gradle/foo.yml"));
     }
 
+    @Test
+    void trackedFilesMatchingGitIgnoreAreNotIgnored() throws Exception {
+        initGit(repo);
+
+        // Create and commit files first
+        Path trackedFile = repo.resolve("tracked.xml");
+        touch(trackedFile);
+        Path trackedInDir = repo.resolve("config/settings.xml");
+        mkdirs(trackedInDir.getParent().toFile());
+        touch(trackedInDir);
+
+        try (Git git = Git.open(repo.toFile())) {
+            git.add().addFilepattern("tracked.xml").addFilepattern("config/settings.xml").call();
+            git.commit().setSign(false).setMessage("add tracked files").call();
+
+            // Now add them to .gitignore (but don't git rm them — they remain tracked)
+            writeString(repo.resolve(".gitignore"), "tracked.xml\nconfig/\n");
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setSign(false).setMessage("add gitignore").call();
+        }
+
+        OmniParser parser = OmniParser.builder(OmniParser.defaultResourceParsers()).build();
+        List<Path> paths = parser.acceptedPaths(repo);
+        assertThat(paths).extracting(p -> repo.relativize(p).toString()).contains(
+                "tracked.xml",
+                separatorsToSystem("config/settings.xml")
+        );
+    }
+
+    @Test
+    void untrackedFilesMatchingGitIgnoreAreIgnored() throws Exception {
+        initGit(repo);
+
+        // Add .gitignore first
+        writeString(repo.resolve(".gitignore"), "untracked.xml\ntemp/\n");
+        try (Git git = Git.open(repo.toFile())) {
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setSign(false).setMessage("add gitignore").call();
+        }
+
+        // Create files that are never committed — they should be ignored
+        touch(repo.resolve("untracked.xml"));
+        mkdirs(repo.resolve("temp").toFile());
+        touch(repo.resolve("temp/data.xml"));
+
+        OmniParser parser = OmniParser.builder(OmniParser.defaultResourceParsers()).build();
+        List<Path> paths = parser.acceptedPaths(repo);
+        assertThat(paths).extracting(p -> repo.relativize(p).toString()).doesNotContain(
+                "untracked.xml",
+                separatorsToSystem("temp/data.xml")
+        );
+    }
+
     void initGit(Path repositoryPath) {
         try (Git git = Git.init().setDirectory(repositoryPath.toFile()).call()) {
             git.remoteSetUrl().setRemoteName("origin").setRemoteUri(


### PR DESCRIPTION
## Problem

`OmniParser.acceptedPaths()` uses `FileTreeIterator.isEntryIgnored()` to skip files and directories matching `.gitignore` rules. However, this API only checks ignore rules — it does not consult the git index to determine whether a file is actually tracked.

This means files that are:
1. **Committed and tracked** in the git repository, but
2. **Later added** to `.gitignore`

...are incorrectly excluded from parsing. Git itself continues to track these files until they are explicitly `git rm`'d.

- This is the same bug that was fixed in the Moderne CLI in [moderneinc/moderne-cli#3462](https://github.com/moderneinc/moderne-cli/pull/3462), for the `RepositoryDirectory.scanAllIgnoredPaths()` code path. `OmniParser.acceptedPaths()` is a separate code path used during non-code file discovery that has the same issue.

- Related: https://github.com/moderneinc/moderne-cli/issues/3460

## Solution

Add a `DirCacheIterator` (git index) to the `TreeWalk` alongside the `FileTreeIterator`, and link them via `setDirCacheIterator()`. This has two effects:

1. **Subtree traversal**: JGit's `FileTreeIterator.createSubtreeIterator()` checks for a `DirCacheIterator` before skipping ignored directories — if tracked content exists under the directory, it enters the subtree instead of returning an `EmptyTreeIterator`.

2. **File-level check**: Each entry is only treated as ignored if `isEntryIgnored()` returns true **and** the `DirCacheIterator` is null at that position (meaning the file is not in the index).

## Test plan
- [x] `trackedFilesMatchingGitIgnoreAreNotIgnored` — commits files (including inside a directory), adds them to `.gitignore`, verifies they are still included in `acceptedPaths`
- [x] `untrackedFilesMatchingGitIgnoreAreIgnored` — verifies genuinely untracked ignored files and directories are still properly skipped
- [x] All existing `OmniParserTest` tests pass