### PR TITLE
OmniParser: forward JavaTypeFactory to default Groovy/Gradle parsers

### DIFF
--- a/src/main/java/org/openrewrite/polyglot/OmniParser.java
+++ b/src/main/java/org/openrewrite/polyglot/OmniParser.java
@@ -26,6 +26,7 @@ import org.openrewrite.docker.DockerParser;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.groovy.GroovyParser;
 import org.openrewrite.hcl.HclParser;
+import org.openrewrite.java.internal.JavaTypeFactory;
 import org.openrewrite.jgit.api.Git;
 import org.openrewrite.jgit.dircache.DirCacheIterator;
 import org.openrewrite.jgit.lib.FileMode;
@@ -101,8 +102,26 @@ public class OmniParser implements Parser {
      * what the division of labor should be between PlainText and the Quark parsers, if any.
      */
     public static List<Parser> defaultResourceParsers() {
+        return defaultResourceParsers(null);
+    }
+
+    /**
+     * Like {@link #defaultResourceParsers()} but routes {@link GroovyParser} and
+     * {@link GradleParser} through the supplied {@code typeFactory}. Callers that
+     * also feed type-producing parsers (Java, Kotlin, ...) into the same OmniParser
+     * must pass the shared factory here, otherwise the resource-side Groovy/Gradle
+     * parsers mint a parallel JavaType graph that collides with the typed parsers'
+     * graph when both write into the same downstream type table.
+     */
+    public static List<Parser> defaultResourceParsers(@Nullable JavaTypeFactory typeFactory) {
         // do not assign to static field, or class initialization on OmniParser will
         // cause these parsers to get built, potentially triggering undesirable side effects
+        GroovyParser.Builder groovy = GroovyParser.builder();
+        GradleParser.Builder gradle = GradleParser.builder();
+        if (typeFactory != null) {
+            groovy.typeFactory(typeFactory);
+            gradle.typeFactory(typeFactory);
+        }
         return new ArrayList<>(asList(
                 new JsonParser(),
                 new XmlParser(),
@@ -112,8 +131,8 @@ public class OmniParser implements Parser {
                 new TomlParser(),
                 new DockerParser(),
                 HclParser.builder().build(),
-                GroovyParser.builder().build(),
-                GradleParser.builder().build()
+                groovy.build(),
+                gradle.build()
         ));
     }
 


### PR DESCRIPTION
## Summary

Adds a `defaultResourceParsers(@Nullable JavaTypeFactory)` overload to `OmniParser` that threads a caller-supplied factory through the built-in `GroovyParser` and `GradleParser`. The existing no-arg overload delegates with `null` for backwards compatibility.

## Why

Callers that mix `OmniParser` with type-producing parsers (Java, Kotlin, ...) under a single shared `JavaTypeCache` had no way to keep the resource-side Groovy/Gradle parsers on the same factory. The defaults built a private `DefaultJavaTypeFactory`, so when a `.gradle` / `.groovy` file under a Java source set's resources reached `OmniParser`, the resulting `JavaType.Class` instances were distinct from those minted by the Java parser for the same FQN.

Concretely, this surfaced building spring-boot with the moderne-cli V3 type-table writer: `spring-boot-gradle-plugin/src/dockerTest/resources/` carries ~30 `BootBuildImageIntegrationTests-*.gradle` test fixtures. `GradleParser` claimed them under its private factory, producing duplicate `JavaType.Class` instances for shared FQNs (`org.gradle.api.Incubating`, `org.gradle.testkit.runner.BuildResult`, …). The writer's per-FQN dedup threw on the second add.

The fix in the moderne-cli call sites is to pass the shared `TypeTableBackedJavaTypeFactory` through to this new overload; consumers that don't need a shared factory get the same behavior as before.

## Test plan

- [x] Existing tests pass (no behavior change for the no-arg overload).
- [x] Verified end-to-end against moderne-cli's V3 spring-boot reproduction: the `Incubating` / `BuildResult.getOutput` duplicate writes from `dockerTest` are gone after switching the cli to the new overload.